### PR TITLE
New task to subscribe to satellite 6 using activation key

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Performs a migration from CFME 5.7 to 5.8 utilizing steps from [Migrating to Red
 | parameter                    | required | default | choices | comments
 |------------------------------|----------|---------|---------|-------------------------------------------------------------------
 | cfme_addiitonal_repositories | No       |         |         | Additional repositories to configure when performing the migration
+| sat6_org_id                  | No       |         |         | Satellite 6 organization ID (when using activation key below)
+| sat6_activation_key          | No       |         |         | Satellite 6 activation key (instead of direct subscribe to repos)
 
 ### migrate-5-8-to-5-9.yml
 Performs a migration from CFME 5.8 to 5.9 utilizing steps from [Migrating to Red Hat CloudForms 4.6](https://access.redhat.com/documentation/en-us/red_hat_cloudforms/4.6/html/migrating_to_red_hat_cloudforms_4.6/).  This playbook does not currently perform a backup, resize the disks or handle database replication scenarios.
@@ -40,6 +42,8 @@ Performs a migration from CFME 5.8 to 5.9 utilizing steps from [Migrating to Red
 | parameter                    | required | default | choices | comments
 |------------------------------|----------|---------|---------|-------------------------------------------------------------------
 | cfme_addiitonal_repositories | No       |         |         | Additional repositories to configure when performing the migration
+| sat6_org_id                  | No       |         |         | Satellite 6 organization ID (when using activation key below)
+| sat6_activation_key          | No       |         |         | Satellite 6 activation key (instead of direct subscribe to repos)
 
 ### rolling-update.yml
 Performs an update/upgrade of all packages on the CFME appliances and performs a reboot if necessary.
@@ -53,3 +57,5 @@ Performs an update/upgrade of all packages on the CFME appliances and performs a
 | parameter                    | required | default | choices | comments
 |------------------------------|----------|---------|---------|-------------------------------------------------------------------
 | cfme_addiitonal_repositories | No       |         |         | Additional repositories to configure when performing the update
+| sat6_org_id                  | No       |         |         | Satellite 6 organization ID (when using activation key below)
+| sat6_activation_key          | No       |         |         | Satellite 6 activation key (instead of direct subscribe to repos)

--- a/playbooks/migrate-5-7-to-5-8.yml
+++ b/playbooks/migrate-5-7-to-5-8.yml
@@ -3,10 +3,15 @@
   become: True
   gather_facts: True
   tasks:
-    - name: CFME | Migrate | Repositories
+    - name: CFME | Migrate | Subscribe Using Activation Key
+      include_tasks: tasks/configure-activation-key.yml
+      when: sat6_activation_key is defined
+
+    - name: CFME | Migrate | Subscribe Using Repositories
       include_tasks: tasks/configure-repositories.yml
       vars:
         cfme_version_product: 5.8
+      when: sat6_activation_key is not defined
 
 - name: CFME | Migrate | 5.7 to 5.8 | Appliances Specific Preparation
   hosts: cfme-appliances

--- a/playbooks/migrate-5-8-to-5-9.yml
+++ b/playbooks/migrate-5-8-to-5-9.yml
@@ -3,10 +3,15 @@
   become: True
   gather_facts: True
   tasks:
-    - name: CFME | Migrate | Repositories
+    - name: CFME | Migrate | Subscribe Using Activation Key
+      include_tasks: tasks/configure-activation-key.yml
+      when: sat6_activation_key is defined
+
+    - name: CFME | Migrate | Subscribe Using Repositories
       include_tasks: tasks/configure-repositories.yml
       vars:
         cfme_version_product: 5.9
+      when: sat6_activation_key is not defined
 
 - name: CFME | Migrate | 5.8 to 5.9 | Appliances Specific Preparation
   hosts: cfme-appliances

--- a/playbooks/rolling-update.yml
+++ b/playbooks/rolling-update.yml
@@ -4,8 +4,13 @@
   become: True
   gather_facts: True
   tasks:
+    - name: CFME | Rolling Update | Include Tasks for Subscribing Using Activation Key
+      include_tasks: tasks/configure-activation-key.yml
+      when: sat6_activation_key is defined
+
     - name: CFME | Rolling Update | Include Tasks for Configuring Repositories
       include_tasks: tasks/configure-repositories.yml
+      when: sat6_activation_key is not defined
 
     - name: CFME | Rolling Update | Any package updates required?
       command: 'yum check-update'

--- a/tasks/configure-activation-key.yml
+++ b/tasks/configure-activation-key.yml
@@ -2,11 +2,6 @@
 - name: CFME | Subscribe Using Activation Key | Incluide Tasks for Installing Custom Facts
   include_tasks: tasks/install-custom-facts.yml
 
-- name: CFME | Subscribe Using Activation Key | Set Satellite 6 Activation Key Name
-  set_fact:
-    sat6_activation_key: "{{ ansible_local['cfme']['sat6_activation_key'] }}"
-  when: sat6_activation_key is not defined
-
 - name: CFME | Subscribe Using Activation Key | Re-register Host With New Satellite 6 Activation Key
   redhat_subscription:
     state: present

--- a/tasks/configure-activation-key.yml
+++ b/tasks/configure-activation-key.yml
@@ -1,0 +1,15 @@
+---
+- name: CFME | Subscribe Using Activation Key | Incluide Tasks for Installing Custom Facts
+  include_tasks: tasks/install-custom-facts.yml
+
+- name: CFME | Subscribe Using Activation Key | Set Satellite 6 Activation Key Name
+  set_fact:
+    sat6_activation_key: "{{ ansible_local['cfme']['sat6_activation_key'] }}"
+  when: sat6_activation_key is not defined
+
+- name: CFME | Subscribe Using Activation Key | Re-register Host With New Satellite 6 Activation Key
+  redhat_subscription:
+    state: present
+    org_id: "{{ sat6_org_id }}"
+    activationkey: "{{ sat6_activation_key }}"
+    force_register: true


### PR DESCRIPTION
I wrote a new task to allow configuration of the proper repositories using Satellite 6 activation key, rather than directly subscribing to the repositories. I hope this is useful for someone.

To use this, just define the variables "sat6_org_id" and "sat6_activation_key" on your inventory file.