### PR TITLE
Issue #21 rolling-update.yml to allow for Specific OS Version 

### DIFF
--- a/playbooks/rolling-update.yml
+++ b/playbooks/rolling-update.yml
@@ -8,7 +8,7 @@
       include_tasks: tasks/configure-repositories.yml
 
     - name: CFME | Rolling Update | Any package updates required?
-      command: 'yum check-update'
+      command: 'yum check-update --releasever={{ ansible_release_version }}'
       args:
         warn: no
       register: packages_need_update_result

--- a/playbooks/rolling-update.yml
+++ b/playbooks/rolling-update.yml
@@ -8,12 +8,22 @@
       include_tasks: tasks/configure-repositories.yml
 
     - name: CFME | Rolling Update | Any package updates required?
-      command: 'yum check-update --releasever={{ ansible_release_version }}'
+      command: "yum check-update --releasever={{ releasever }}"
       args:
         warn: no
       register: packages_need_update_result
       changed_when: packages_need_update_result.rc == 100
       failed_when: packages_need_update_result.rc != 0 and packages_need_update_result.rc != 100
+      when: releasever is defined
+
+    - name: CFME | Rolling Update | Any package updates required?
+      command: "yum check-update"
+      args:
+        warn: no
+      register: packages_need_update_result
+      changed_when: packages_need_update_result.rc == 100
+      failed_when: packages_need_update_result.rc != 0 and packages_need_update_result.rc != 100
+      when: releasever is undefined
 
 - name: CFME | Rolling Update | Update Databases
   hosts: cfme-databases

--- a/tasks/update-packages.yml
+++ b/tasks/update-packages.yml
@@ -12,7 +12,14 @@
   when: "'cfme-databases' in group_names"
 
 - name: CFME | Update Packages | Latest
-  command: "yum update -y --releasever={{ ansible_release_version }}"
+  command: "yum update -y --releasever={{ releasever }}"
+  when: releasever is defined
+  
+- name: CFME | Update Packages | Latest
+  yum:
+    name: "*"
+    state: latest
+  when: releasever is undefined
   
 - name: CFME | Update Packages | Include Tasks for Host Reboot
   include_tasks: tasks/host-reboot.yml

--- a/tasks/update-packages.yml
+++ b/tasks/update-packages.yml
@@ -12,10 +12,8 @@
   when: "'cfme-databases' in group_names"
 
 - name: CFME | Update Packages | Latest
-  package:
-    name: '*'
-    state: latest
-    
+  command: "yum update -y --releasever={{ ansible_release_version }}"
+  
 - name: CFME | Update Packages | Include Tasks for Host Reboot
   include_tasks: tasks/host-reboot.yml
 


### PR DESCRIPTION
Updates lock to the current Red Hat release version installed on the system using the "{{ ansible_release_version }}" default fact and the "--releasever" flag on yum