### PR TITLE
Use wait_for_connection module over wait_for after reboot

### DIFF
--- a/tasks/host-reboot.yml
+++ b/tasks/host-reboot.yml
@@ -23,12 +23,8 @@
   when: needs_restart_result.changed or not reboot_only_if_needed
 
 - name: Host Reboot | Wait for host after reboot
-  wait_for:
-    host: "{{ ansible_hostname }}"
+  wait_for_connection:
     delay: 65
-    port: 22
-    state: started
     timeout: 600
-  delegate_to: localhost
   become: False
   when: redhat_reboot.changed


### PR DESCRIPTION
[wait_for_connection](http://docs.ansible.com/ansible/latest/modules/wait_for_connection_module.html) is a more robust way to check that a host is accessible after a reboot.

It accounts for connection information already known by Ansible, allowing for non-standard ports, transports, etc more easily.

Addresses concerns raised in issue #25 