### PR TITLE
Disable Medium SSL Ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,3 +164,10 @@ Changes the VMDB PostgreSQL password, updates the database.yml files, and restar
 | parameter        | required | default | comments
 |------------------|----------|---------|--------------------------------------------------------------------
 | vmdb\_password   | Yes      |         | This is the new password to use for the VMDB PostgreSQL account.
+
+### disable-medium-ssl-ciphers.yml
+Disables Medium SSL Ciphers in the CloudForms webserver configuration (/etc/httpd/conf.d/manageiq-https-application.conf).
+* Addresses Tenable finding https://www.tenable.com/plugins/nessus/42873
+
+#### Required groups
+* cfme-appliancees

--- a/playbooks/disable-medium-ssl-ciphers.yml
+++ b/playbooks/disable-medium-ssl-ciphers.yml
@@ -1,0 +1,31 @@
+---
+- name: CFME | Disable Medium SSL Cipher Suites within CloudForms Configuration
+  hosts: cfme-appliances
+  gather_facts: True
+  handlers:
+    - name: CFME | Restart HTTPD
+      become: True
+      service:
+        name: httpd
+        state: reloaded
+      listen: "Restart HTTPD"
+    - name: CFME | Test HTTPD Port
+      wait_for:
+        port: 80
+        state: started
+      listen: "Restart HTTPD"
+    - name: CFME | Health Check | Include Tasks
+      include_tasks: tasks/perform-health-check.yml
+      listen: "Restart HTTPD"
+  tasks:
+    # Finding https://www.tenable.com/plugins/nessus/42873
+    - name: CFME | Disable Medium SSL Cipher Suites
+      become: True
+      lineinfile:
+        path: /etc/httpd/conf.d/manageiq-https-application.conf
+        regexp: '^SSLCipherSuite |^r"SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:!LOW:!SSLv2:!EXPORT"'
+        line: "SSLCipherSuite ALL:!ADH:RC4+RSA:+HIGH:+MEDIUM:!LOW:!SSLv2:!EXPORT"
+        state: present
+        backrefs: True
+        backup: True
+      notify: "Restart HTTPD"

--- a/playbooks/health-check.yml
+++ b/playbooks/health-check.yml
@@ -3,15 +3,5 @@
   hosts: cfme-appliances
   gather_facts: True
   tasks:
-    - name: CFME | Health Check | Ping Check
-      local_action:
-        module: uri
-        url: "https://{{ ansible_hostname }}/ping"
-        method: GET
-        validate_certs: False
-        body_format: raw
-        return_content: Yes
-      register: cfme_ping_check_result
-      until: cfme_ping_check_result['content'] == 'pong'
-      retries: 60
-      delay: 5
+    - name: CFME | Health Check | Include Tasks
+      include_tasks: tasks/perform-health-check.yml

--- a/tasks/perform-health-check.yml
+++ b/tasks/perform-health-check.yml
@@ -1,0 +1,13 @@
+---
+- name: CFME | Health Check | Ping Check
+  local_action:
+    module: uri
+    url: "https://{{ ansible_fqdn }}:443/ping"
+    method: GET
+    validate_certs: False
+    body_format: raw
+    return_content: Yes
+  register: cfme_ping_check_result
+  until: cfme_ping_check_result['content'] == 'pong'
+  retries: 60
+  delay: 5


### PR DESCRIPTION
Moved health check tasks to tasks to centralize and added playbook to disable medium ssl ciphers.