### PR TITLE
Add a playbook that does a non-rolling update

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,21 @@ Performs an update/upgrade of all packages on the CFME appliances and performs a
 | sat6_org_id                  | No       |         |         | Satellite 6 organization ID (when using activation key below)
 | sat6_activation_key          | No       |         |         | Satellite 6 activation key (instead of direct subscribe to repos)
 
+### simultaneous-update.yml
+Performs an update/upgrade of all packages on all CFME appliances at the same time, and performs a reboot if necessary.
+
+#### Required groups
+* cfme
+* cfme-appliancees
+* cfme-databases
+
+#### Options
+| parameter                    | required | default | choices | comments
+|------------------------------|----------|---------|---------|-------------------------------------------------------------------
+| cfme_addiitonal_repositories | No       |         |         | Additional repositories to configure when performing the update
+| sat6_org_id                  | No       |         |         | Satellite 6 organization ID (when using activation key below)
+| sat6_activation_key          | No       |         |         | Satellite 6 activation key (instead of direct subscribe to repos)
+
 ### smoke-test-service-provision.yml
 Smoke tests Service template provisioning and retirment.
 

--- a/playbooks/simultaneous-update.yml
+++ b/playbooks/simultaneous-update.yml
@@ -30,9 +30,6 @@
       failed_when: packages_need_update_result.rc != 0 and packages_need_update_result.rc != 100
       when: releasever is undefined
 
-- name: CFME | Update | Stop All Services
-  import_playbook: stop-services.yml
-
 - name: CFME | Update | Update Databases
   hosts: cfme-databases
   become: True
@@ -50,9 +47,6 @@
     - name: CFME | Update | Include Tasks for Updating Packages
       include_tasks: tasks/update-packages.yml
       when: packages_need_update_result | changed
-
-- name: CFME | Update | Ensure all Services Started
-  import_playbook: start-services.yml
 
 - name: CFME | Update | wait for API to report ready
   import_playbook: health-check.yml

--- a/playbooks/simultaneous-update.yml
+++ b/playbooks/simultaneous-update.yml
@@ -1,0 +1,58 @@
+---
+- name: CFME | Update | All Preparation
+  hosts: cfme
+  become: True
+  gather_facts: True
+  tasks:
+    - name: CFME | Update | Include Tasks for Subscribing Using Activation Key
+      include_tasks: tasks/configure-activation-key.yml
+      when: sat6_activation_key is defined
+
+    - name: CFME | Update | Include Tasks for Configuring Repositories
+      include_tasks: tasks/configure-repositories.yml
+      when: sat6_activation_key is not defined
+
+    - name: CFME | Update | Any package updates required?
+      command: "yum check-update --releasever={{ releasever }}"
+      args:
+        warn: no
+      register: packages_need_update_result
+      changed_when: packages_need_update_result.rc == 100
+      failed_when: packages_need_update_result.rc != 0 and packages_need_update_result.rc != 100
+      when: releasever is defined
+
+    - name: CFME | Update | Any package updates required?
+      command: "yum check-update"
+      args:
+        warn: no
+      register: packages_need_update_result
+      changed_when: packages_need_update_result.rc == 100
+      failed_when: packages_need_update_result.rc != 0 and packages_need_update_result.rc != 100
+      when: releasever is undefined
+
+- name: CFME | Update | Stop All Services
+  import_playbook: stop-services.yml
+
+- name: CFME | Update | Update Databases
+  hosts: cfme-databases
+  become: True
+  gather_facts: False
+  tasks:
+    - name: CFME | Update | Include Tasks for Updating Packages
+      include_tasks: tasks/update-packages.yml
+      when: packages_need_update_result | changed
+
+- name: CFME | Update | Update Appliances
+  hosts: cfme-appliances:!cfme-databases
+  become: True
+  gather_facts: False
+  tasks:
+    - name: CFME | Update | Include Tasks for Updating Packages
+      include_tasks: tasks/update-packages.yml
+      when: packages_need_update_result | changed
+
+- name: CFME | Update | Ensure all Services Started
+  import_playbook: start-services.yml
+
+- name: CFME | Update | wait for API to report ready
+  import_playbook: health-check.yml


### PR DESCRIPTION
Patches/restarts the DB appliance, then patches/reboots all non-DB appliances at the same time.