### PR TITLE
Update Health Check Playbook

### DIFF
--- a/playbooks/health-check.yml
+++ b/playbooks/health-check.yml
@@ -4,4 +4,4 @@
   gather_facts: True
   tasks:
     - name: CFME | Health Check | Include Tasks
-      include_tasks: tasks/perform-health-check.yml
+      import_tasks: tasks/perform-health-check.yml

--- a/tasks/perform-health-check.yml
+++ b/tasks/perform-health-check.yml
@@ -1,4 +1,12 @@
 ---
+
+- name: CFME | Health Check | Port 443 is listening
+  wait_for:
+    host: "{{ ansible_fqdn }}"
+    port: 443
+    state: started
+    timeout: 60
+
 - name: CFME | Health Check | Ping Check
   local_action:
     module: uri
@@ -8,6 +16,7 @@
     body_format: raw
     return_content: Yes
   register: cfme_ping_check_result
-  until: cfme_ping_check_result['content'] == 'pong'
+  until: "cfme_ping_check_result['content'] is defined and cfme_ping_check_result['content'] == 'pong'"
   retries: 60
   delay: 5
+


### PR DESCRIPTION
+ changing from including to importing task file to allow for easy
syntax checking
+ Adding wait for port 443 on CFME appliance
+ Ensuring http response is populated before checking content