### PR TITLE
Making changes to remove deprication warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 *.retry
+.vscode

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Performs a migration from CFME 5.7 to 5.8 utilizing steps from [Migrating to Red
 
 #### Required groups
 * cfme
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 #### Options
 | parameter                    | required | default | choices | comments
@@ -35,8 +35,8 @@ Performs a migration from CFME 5.8 to 5.9 utilizing steps from [Migrating to Red
 
 #### Required groups
 * cfme
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 #### Options
 | parameter                    | required | default | choices | comments
@@ -55,8 +55,8 @@ Performs a migration from CFME 5.9 to 5.10 utilizing steps from [Migrating to Re
 
 #### Required groups
 * cfme
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 #### Options
 | parameter                    | required | default | choices | comments
@@ -70,8 +70,8 @@ Performs an update/upgrade of all packages on the CFME appliances and performs a
 
 #### Required groups
 * cfme
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 #### Options
 | parameter                    | required | default | choices | comments
@@ -85,8 +85,8 @@ Performs an update/upgrade of all packages on all CFME appliances at the same ti
 
 #### Required groups
 * cfme
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 #### Options
 | parameter                    | required | default | choices | comments
@@ -99,7 +99,7 @@ Performs an update/upgrade of all packages on all CFME appliances at the same ti
 Smoke tests Service template provisioning and retirment.
 
 #### Required groups
-* cfme-ui-appliances
+* cfme_ui_appliances
 
 #### Options
 | parameter                                 | required | default | comments
@@ -118,34 +118,34 @@ Smoke tests Service template provisioning and retirment.
 Start all of the DB services then all of the Appliance services.
 
 #### Required groups
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 ### stop-services.yml
 Stop all of the Appliance services then all of the DB services.
 
 #### Required groups
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 ### full-stop-start-services.yml
 Stop all of the Appliance services, then all of the DB services, then start all of the DB services, then all of the Appliance services, then perform a helath check.
 
 #### Required groups
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 ### health-check.yml
 Checks the health of the Appliances.
 
 #### Required groups
-* cfme-appliancees
+* cfme_appliancees
 
 ### gather-logs.yml
 Gathers relevant logs from all of the appliances and puts them in an archive on the first DB host. Optionally emails the archive.
 
 #### Required groups
-* cfme-databases
+* cfme_databases
 
 #### Options
 | parameter                       | required | default | comments
@@ -192,8 +192,8 @@ Changes the VMDB PostgreSQL password, updates the database.yml files, and restar
 * The playbook can be run with `ansible-playbook --vault-id @prompt playbooks/change_vmdb_password.yml` to prompt for the Ansible Vault password.
 
 #### Required groups
-* cfme-appliancees
-* cfme-databases
+* cfme_appliancees
+* cfme_databases
 
 #### Options
 | parameter        | required | default | comments
@@ -205,4 +205,5 @@ Disables Medium SSL Ciphers in the CloudForms webserver configuration (/etc/http
 * Addresses Tenable finding https://www.tenable.com/plugins/nessus/42873
 
 #### Required groups
-* cfme-appliancees
+* cfme_appliancees
+

--- a/files/inventory
+++ b/files/inventory
@@ -1,10 +1,10 @@
 [cfme:children]
-cfme-databases
-cfme-appliances
+cfme_databases
+cfme_appliances
 
 # All applicances which are running evmserverd including database appliances which are not standalone.
 # Do not include HA / standalone databasees which are not running evmserverd here.
-[cfme-appliances]
+[cfme_appliances]
 cfmedb01 # Application running on database appliance.
 cfmeui01
 cfmeui02
@@ -14,7 +14,7 @@ cfmewk03
 
 # Any appliance with VMDB database running.
 # HA / standalone or VMDB with application running too.
-[cfme-databases]
+[cfme_databases]
 cfmedb01 # Application running on database appliance.
 cfmehadb01 # HA database
 cfmehadb02 # HA database

--- a/playbooks/change_vmdb_password.yml
+++ b/playbooks/change_vmdb_password.yml
@@ -1,5 +1,5 @@
 - name: CFME | Change VMDB Password | Appliances Specific Preparation
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   become_method: su
   gather_facts: False
@@ -14,7 +14,7 @@
       shell: "/var/www/miq/vmdb/tools/fix_auth.rb --databaseyml --password '{{ vmdb_password }}'"
 
 - name: CFME | Change VMDB Password | Change PostgreSQL Password
-  hosts: "{{ groups['cfme-databases'][0] }}"
+  hosts: "{{ groups['cfme_databases'][0] }}"
   become: True
   gather_facts: False
   vars_files:
@@ -31,7 +31,7 @@
         password: "{{ vmdb_password }}"
 
 - name: CFME | Change VMDB Password | Restart evmserverd
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:

--- a/playbooks/disable-medium-ssl-ciphers.yml
+++ b/playbooks/disable-medium-ssl-ciphers.yml
@@ -1,6 +1,6 @@
 ---
 - name: CFME | Disable Medium SSL Cipher Suites within CloudForms Configuration
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   gather_facts: True
   handlers:
     - name: CFME | Restart HTTPD

--- a/playbooks/health-check.yml
+++ b/playbooks/health-check.yml
@@ -1,6 +1,6 @@
 ---
 - name: CFME | Health Check
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   gather_facts: True
   tasks:
     - name: CFME | Health Check | Include Tasks

--- a/playbooks/migrate-5-7-to-5-8.yml
+++ b/playbooks/migrate-5-7-to-5-8.yml
@@ -14,7 +14,7 @@
       when: sat6_activation_key is not defined
 
 - name: CFME | Migrate | 5.7 to 5.8 | Appliances Specific Preparation
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -24,7 +24,7 @@
         state: stopped
 
 - name: CFME | Migrate | 5.7 to 5.8 | DB Specific Preparation
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -44,7 +44,7 @@
         state: latest
 
 - name: CFME | Migrate | 5.7 to 5.8 | Start postgresql
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -54,7 +54,7 @@
         state: started
 
 - name: CFME | Migrate | 5.8 to 5.9 | Wait for postgresql
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -64,7 +64,7 @@
         delay: 120
 
 - name: CFME | Migrate | 5.7 to 5.8 | DB Migration
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -81,7 +81,7 @@
       poll: 60
 
 - name: CFME | Migrate | 5.7 to 5.8 | Post DB Migrate Restart
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -91,7 +91,7 @@
         state: restarted
 
 - name: CFME | Migrate | 5.7 to 5.8 | Check Schema
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -113,7 +113,7 @@
         - evm_check_schema
 
 - name: CFME | Migrate | 5.7 to 5.8 | Restart evmserverd
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:

--- a/playbooks/migrate-5-8-to-5-9.yml
+++ b/playbooks/migrate-5-8-to-5-9.yml
@@ -14,7 +14,7 @@
       when: sat6_activation_key is not defined
 
 - name: CFME | Migrate | 5.8 to 5.9 | Appliances Specific Preparation
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -24,7 +24,7 @@
         state: stopped
 
 - name: CFME | Migrate | 5.8 to 5.9 | DB Specific Preparation
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -44,7 +44,7 @@
         state: latest
 
 - name: CFME | Migrate | 5.8 to 5.9 | Start postgresql
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -54,7 +54,7 @@
         state: started
 
 - name: CFME | Migrate | 5.8 to 5.9 | Wait for postgresql
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -64,7 +64,7 @@
         delay: 120
 
 - name: CFME | Migrate | 5.8 to 5.9 | DB Migration
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -79,7 +79,7 @@
       shell: "cd /var/www/miq/vmdb; rake evm:automate:reset > >(tee /var/tmp/evm_automate_reset.out) 2> >(tee /var/tmp/evm_automate_reset.err >&2)"
 
 - name: CFME | Migrate | 5.8 to 5.9 | Post DB Migrate Restart
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -89,7 +89,7 @@
         state: restarted
 
 - name: CFME | Migrate | 5.8 to 5.9 | Restart evmserverd
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:

--- a/playbooks/migrate-5-9-to-5-10.yml
+++ b/playbooks/migrate-5-9-to-5-10.yml
@@ -15,7 +15,7 @@
       when: sat6_activation_key is not defined
 
 - name: CFME | Migrate | 5.9 to 5.10 | Appliances Specific Preparation
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -25,7 +25,7 @@
         state: stopped
 
 - name: CFME | Migrate | 5.9 to 5.10 | DB Specific Preparation
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -45,7 +45,7 @@
         state: latest
 
 - name: CFME | Migrate | 5.9 to 5.10 | Start postgresql
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -55,7 +55,7 @@
         state: started
 
 - name: CFME | Migrate | 5.9 to 5.10 | Wait for postgresql
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -65,7 +65,7 @@
         delay: 120
 
 - name: CFME | Migrate | 5.9 to 5.10 | DB Migration
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -90,7 +90,7 @@
         executable: /bin/bash
 
 - name: CFME | Migrate | 5.9 to 5.10 | Post DB Migrate Restart
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -100,7 +100,7 @@
         state: restarted
 
 - name: CFME | Migrate | 5.9 to 5.10 | Restart evmserverd
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:

--- a/playbooks/rolling-update.yml
+++ b/playbooks/rolling-update.yml
@@ -31,7 +31,7 @@
       when: releasever is undefined
 
 - name: CFME | Rolling Update | Update Databases
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   serial: 1
@@ -41,7 +41,7 @@
       when: packages_need_update_result is changed
 
 - name: CFME | Rolling Update | Update Appliances
-  hosts: cfme-appliances:!cfme-databases
+  hosts: cfme_appliances:!cfme_databases
   become: True
   gather_facts: False
   serial: 1
@@ -54,7 +54,7 @@
   import_playbook: health-check.yml
 
 - name: CFME | Rolling Update | Reset MIQ and Red Hat Automate Domains
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:

--- a/playbooks/simultaneous-update.yml
+++ b/playbooks/simultaneous-update.yml
@@ -31,28 +31,28 @@
       when: releasever is undefined
 
 - name: CFME | Update | Update Databases
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
     - name: CFME | Update | Include Tasks for Updating Packages
       include_tasks: tasks/update-packages.yml
-      when: packages_need_update_result | changed
+      when: packages_need_update_result is changed
 
 - name: CFME | Update | Update Appliances
-  hosts: cfme-appliances:!cfme-databases
+  hosts: cfme_appliances:!cfme_databases
   become: True
   gather_facts: False
   tasks:
     - name: CFME | Update | Include Tasks for Updating Packages
       include_tasks: tasks/update-packages.yml
-      when: packages_need_update_result | changed
+      when: packages_need_update_result is changed
 
 - name: CFME | Update | Wait for API to report ready
   import_playbook: health-check.yml
 
 - name: CFME | Update | Reset MIQ and Red Hat Automate Domains
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:

--- a/playbooks/smoke-test-service-provision.yml
+++ b/playbooks/smoke-test-service-provision.yml
@@ -9,7 +9,7 @@
 
 - name: CFME | Smoke Test Service Provision
   gather_facts: True
-  hosts: cfme-ui-appliances[0]
+  hosts: cfme_ui_appliances[0]
   tasks:
     - name: CFME | Smoke Test Service Provision | Validate Variables
       assert:

--- a/playbooks/start-services.yml
+++ b/playbooks/start-services.yml
@@ -1,6 +1,6 @@
 ---
 - name: CFME | Start Services | Databases
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:
@@ -10,7 +10,7 @@
         state: started
 
 - name: CFME | Start Services | Appliances
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:

--- a/playbooks/stop-services.yml
+++ b/playbooks/stop-services.yml
@@ -1,6 +1,6 @@
 ---
 - name: CFME | Stop Services | Appliances
-  hosts: cfme-appliances
+  hosts: cfme_appliances
   become: True
   gather_facts: False
   tasks:
@@ -10,7 +10,7 @@
         state: stopped
 
 - name: CFME | Stop Services | Databases
-  hosts: cfme-databases
+  hosts: cfme_databases
   become: True
   gather_facts: False
   tasks:


### PR DESCRIPTION
Change group names to not use hyphens
Do not use `| changed` syntax

Addresses issues:
+ https://github.com/RedHatOfficial/ansible-redhat_cloudforms/issues/44
+ https://github.com/RedHatOfficial/ansible-redhat_cloudforms/issues/43

Users will need to make a one-time change to their inventory files to move from `-` to `_`. The included changes to the checked-in inventory file shows the change required.

Here are the depreciation warnings:

[DEPRECATION WARNING]: Using tests as filters is deprecated. Instead of using `result|changed` use `result is changed`. This feature will be removed in version 2.9. 
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.

[DEPRECATION WARNING]: The TRANSFORM_INVALID_GROUP_CHARS settings is set to allow bad characters in group names by default, this will change, but still be user configurable
 on deprecation. This feature will be removed in version 2.10. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.